### PR TITLE
Update sync.ps1

### DIFF
--- a/sync.ps1
+++ b/sync.ps1
@@ -9,11 +9,11 @@ git pull origin main
 
 # Stage all changes
 
-git add .
+git stage .
 
 # Commit changes with message 'Updated'
 
-git commit -m "Updated"
+git commit -m "Synced"
 
 # Push changes to remote repository on branch 'main'
 


### PR DESCRIPTION
This pull request includes a small change to the `sync.ps1` file. The change updates the commands used for staging and committing changes to improve clarity and consistency.

* [`sync.ps1`](diffhunk://#diff-9ad2fa0a7bb59bd3248c9b70c7dea308ac2fdf850beb80a9ad5066df173f39a0L12-R16): Replaced `git add .` with `git stage .` and updated the commit message from "Updated" to "Synced".